### PR TITLE
cost explorer connection verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,6 @@ dependencies = [
  "aws-sdk-cloudwatch",
  "aws-sdk-costexplorer",
  "aws-sdk-ec2",
- "aws-types",
  "chrono",
  "clap",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ aws-config = { version = "1.8.13", features = ["credentials-login"] }
 aws-sdk-cloudwatch = "1.102.0"
 aws-sdk-costexplorer = "1.109.0"
 aws-sdk-ec2 = "1.207.0"
-aws-types = "1.3.11"
 chrono = "0.4.43"
 clap = { version = "4.5.56", features = ["derive"] }
 directories = "6.0.0"


### PR DESCRIPTION
## Description
This PR finishes up the connection verification to AWS. In the last PR #5, we tackled connecting to EC2 and to Cloudwatch. Here we connect to Cost Explorer. The difference with this one and why I split up the PR's was because this required a little extra work. 

With Cost Explorer, the only region that it is available is `us-east-1`. Therefore, I created a new config off of the credentials from the first with the region hardcoded. I then created the client off this new config, called a simple API and verified it was `Ok()`. 