### PR TITLE
removing cost explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,30 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-costexplorer"
-version = "1.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc415dc6c603c3a578ce72b377043ec908714eea3417f7f304ede831699ba2c8"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-sdk-ec2"
 version = "1.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,7 +1442,6 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-cloudwatch",
- "aws-sdk-costexplorer",
  "aws-sdk-ec2",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 anyhow = "1.0.100"
 aws-config = { version = "1.8.13", features = ["credentials-login"] }
 aws-sdk-cloudwatch = "1.102.0"
-aws-sdk-costexplorer = "1.109.0"
 aws-sdk-ec2 = "1.207.0"
 chrono = "0.4.43"
 clap = { version = "4.5.56", features = ["derive"] }

--- a/src/cloud/mod.rs
+++ b/src/cloud/mod.rs
@@ -1,6 +1,5 @@
-use crate::cloud::types::{ConnectionStatus, CostDataPoint, Instance, MetricDataPoint};
+use crate::cloud::types::{ConnectionStatus, Instance, MetricDataPoint};
 use anyhow::Result;
-use aws_sdk_costexplorer::types::Granularity;
 use chrono::{DateTime, Utc};
 
 pub mod aws;
@@ -22,12 +21,4 @@ pub trait MetricsProvider: Send + Sync {
         start_time: DateTime<Utc>,
         end_time: DateTime<Utc>,
     ) -> Result<Vec<MetricDataPoint>>;
-
-    /// Fetch and compute cost metrics for the given instance IDs
-    async fn fetch_cost_data(
-        &self,
-        start_date: DateTime<Utc>,
-        end_date: DateTime<Utc>,
-        granularity: Granularity,
-    ) -> Result<Vec<CostDataPoint>>;
 }

--- a/src/cloud/types.rs
+++ b/src/cloud/types.rs
@@ -9,7 +9,6 @@ pub struct ConnectionStatus {
 
 #[derive(Debug)]
 pub struct PermissionsCheck {
-    pub cost_explorer_read: bool,
     pub metrics_monitor_read: bool,
     pub instance_describe: bool,
 }
@@ -30,13 +29,4 @@ pub struct MetricDataPoint {
     pub value: f64,
     pub unit: Option<String>,
     pub timestamp: DateTime<Utc>,
-}
-
-#[derive(Debug)]
-pub struct CostDataPoint {
-    pub service: Option<String>,
-    pub amount: f64,
-    pub unit: String,
-    pub period_start: DateTime<Utc>,
-    pub period_end: DateTime<Utc>,
 }

--- a/src/config/check.rs
+++ b/src/config/check.rs
@@ -35,14 +35,6 @@ pub async fn verify_config(config_path: Option<&Path>) -> Result<()> {
             "FAILED"
         }
     );
-    println!(
-        "    Cost Explorer: {}",
-        if status.permissions.cost_explorer_read {
-            "OK"
-        } else {
-            "FAILED"
-        }
-    );
 
     if !status.connected {
         anyhow::bail!("Could not connect to AWS. Check your credentials and permissions.");


### PR DESCRIPTION
## Description
I recently found out that cost explorer costs $0.01 per query. WHAT! Anyways, I am removing cost explorer which is sad because it is the main thing I wanted to use this for sighhh. I am going to pivot to instance metrics since my EC2 instance is going down so maybe we can figure out why with infrawatch. I am going to look into getting the daemon running after this with the current metrics on EC2 and then look into memory. I hope that works! 